### PR TITLE
Allow versions of requests > 2.24.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.24.0
+requests>=2.24.0


### PR DESCRIPTION
Installing drone-python==1.0.0 causes a dependency conflict on the version of requests (I'm using requests==2.32.x elsewhere). Suggest changing the requirement spec to allow v2.24.0 or _later_ versions